### PR TITLE
fix(encode): 32-bit safe pack header check

### DIFF
--- a/src/internal/pack/encode.rs
+++ b/src/internal/pack/encode.rs
@@ -133,7 +133,7 @@ fn encode_header(object_number: usize) -> Vec<u8> {
         0, 0, 0, 2, // generates version 2 only.
     ];
     assert_ne!(object_number, 0); // guarantee self.number_of_objects!=0
-    assert!(object_number < (1 << 32));
+    assert!(object_number <= u32::MAX as usize);
     //TODO: GitError:numbers of objects should < 4G ,
     result.append((object_number as u32).to_be_bytes().to_vec().as_mut()); // to 4 bytes (network byte order aka. big-endian)
     result


### PR DESCRIPTION
## Summary
- replace shift-based upper bound with `u32::MAX` to avoid 32-bit overflow
- keep the pack header object count check equivalent and portable

## Testing
- `cargo build --target i686-unknown-linux-gnu`

---

This PR was primarily authored with Codex using GPT-5.2-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.