### PR TITLE
fix(encode): adjust max pack size for 32-bit targets to prevent overflow

### DIFF
--- a/src/internal/pack/decode.rs
+++ b/src/internal/pack/decode.rs
@@ -113,7 +113,10 @@ impl Pack {
             temp_path.pop();
         }
         let thread_num = thread_num.unwrap_or_else(num_cpus::get);
-        let cache_mem_size = mem_limit.map(|mem_limit| mem_limit * 4 / 5);
+        let cache_mem_size = mem_limit.map(|mem_limit| {
+            // Use wider math to avoid 32-bit overflow when computing 80%.
+            ((mem_limit as u128) * 4 / 5) as usize
+        });
         Pack {
             number: 0,
             signature: ObjectHash::default(),
@@ -836,6 +839,20 @@ mod tests {
             }
             Err(e) => panic!("Decompression failed: {e:?}"),
         }
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn test_pack_new_mem_limit_no_overflow_32bit() {
+        // In the old code, 1.2B * 4 produced an intermediate 4.8B value, which exceeds
+        // 32-bit usize::MAX (~4.29B) and overflowed before a later division; this test
+        // covers that former panic path.
+        let mem_limit = 1_200_000_000usize;
+        let tmp = PathBuf::from("/tmp/.cache_temp");
+        let result = std::panic::catch_unwind(|| {
+            let _p = Pack::new(Some(1), Some(mem_limit), Some(tmp), true);
+        });
+        assert!(result.is_ok(), "Pack::new should not panic on 32-bit");
     }
 
     /// Helper function to run decode tests without delta objects

--- a/src/internal/pack/encode.rs
+++ b/src/internal/pack/encode.rs
@@ -759,8 +759,13 @@ mod tests {
         } else {
             2u64 * 1024 * 1024 * 1024
         };
-        let max_pack_size = usize::try_from(max_pack_size_u64)
-            .expect("pack size cap should fit in usize for this target");
+        let max_pack_size = usize::try_from(max_pack_size_u64).unwrap_or_else(|_| {
+            panic!(
+                "internal assertion failed: pack size cap {} does not fit in usize on this \
+                 target; this should be unreachable given the target_pointer_width configuration",
+                max_pack_size_u64
+            )
+        });
         let mut p = Pack::new(
             None,
             Some(max_pack_size), // 6GB on 64-bit, 2GB on 32-bit


### PR DESCRIPTION
When run `buck2 build //... --target-platforms //platforms:i686-unknown-linux-gnu` on [ci](https://github.com/yueneiqi/cargo-buckal/actions/runs/20692834089/job/59403635574), encounter:

```
error: this arithmetic operation will overflow
   --> vendor/src/internal/pack/encode.rs:758:18
    |
758 |             Some(1024 * 1024 * 1024 * 6), // 6GB
    |                  ^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1073741824_usize * 6_usize`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
```

This PR fixes that.

## Summary
- make pack header size check 32-bit safe
- adjust max pack size for 32-bit targets to prevent overflow

## Testing
- cargo test
- cargo test --target i686-unknown-linux-gnu
- [ci log](https://github.com/yueneiqi/cargo-buckal/actions/runs/20693925946/job/59406326554)

---

This PR was primarily authored with Codex using GPT-5.2-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.