### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -11,6 +11,9 @@ on:
 
 name: Check, Build and Test
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/web3infra-foundation/git-internal/security/code-scanning/7](https://github.com/web3infra-foundation/git-internal/security/code-scanning/7)

In general, this problem is fixed by explicitly specifying a minimal `permissions` block for the workflow or for each job, instead of relying on GitHub’s default `GITHUB_TOKEN` permissions. For jobs that only need to read the repository (checkout, build, test), `contents: read` is typically sufficient. Jobs that must write to pull requests or other resources can request more specific write permissions.

The best fix here, without changing existing functionality, is to add a root-level `permissions` block that applies to all jobs, setting `contents: read` as the default. The `clippy` job already has a more permissive `permissions` block (`contents: read`, `pull-requests: write`), which will continue to override the root default for that job. This change ensures that the `format`, `redundancy`, `build`, and `test` jobs all operate with minimal read-only repo access for the `GITHUB_TOKEN`. Concretely, in `.github/workflows/base.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Check, Build and Test` line and the `concurrency:` block. No imports or other definitions are required since this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
