### PR TITLE
Optimize pack decode scheduling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,4 @@ ureq = "3"
 [features]
 default = ["diff_mydrs"]
 diff_mydrs = []
+decode_profile = []

--- a/examples/decode_bench.rs
+++ b/examples/decode_bench.rs
@@ -1,0 +1,275 @@
+//! Decode benchmark harness.
+//!
+//! Example:
+//! cargo run --release --features decode_profile --example decode_bench -- \
+//!   --pack tests/data/packs/medium-sha1.pack --hash sha1 --threads 2 \
+//!   --mem-limit-mb 1024 --warmups 1 --runs 5 --out target/decode-bench.jsonl
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, BufReader, Write},
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Instant,
+};
+
+use git_internal::{
+    hash::{HashKind, ObjectHash, set_hash_kind},
+    internal::pack::Pack,
+};
+use serde_json::json;
+
+#[cfg(not(feature = "decode_profile"))]
+#[derive(Clone, Copy, Debug, Default)]
+struct DecodeProfileSnapshot {
+    cache_hits: usize,
+    cache_misses: usize,
+    fallback_loads: usize,
+    base_objects: usize,
+    delta_objects: usize,
+    waitlist_inserts: usize,
+    waitlist_takes: usize,
+    delta_rebuilds: usize,
+    peak_internal_memory_bytes: usize,
+}
+
+#[cfg(feature = "decode_profile")]
+fn profile_reset() {
+    git_internal::internal::pack::profile::reset();
+}
+
+#[cfg(not(feature = "decode_profile"))]
+fn profile_reset() {}
+
+#[cfg(feature = "decode_profile")]
+fn profile_snapshot() -> git_internal::internal::pack::profile::DecodeProfileSnapshot {
+    git_internal::internal::pack::profile::snapshot()
+}
+
+#[cfg(not(feature = "decode_profile"))]
+fn profile_snapshot() -> DecodeProfileSnapshot {
+    DecodeProfileSnapshot::default()
+}
+
+#[derive(Debug)]
+struct Config {
+    pack: PathBuf,
+    hash: HashKind,
+    threads: usize,
+    mem_limit_mb: Option<usize>,
+    warmups: usize,
+    runs: usize,
+    out: Option<PathBuf>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::parse()?;
+    set_hash_kind(config.hash);
+
+    let mut writer: Box<dyn Write> = match &config.out {
+        Some(path) => {
+            if let Some(parent) = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                std::fs::create_dir_all(parent)?;
+            }
+            Box::new(File::create(path)?)
+        }
+        None => Box::new(io::stdout().lock()),
+    };
+
+    for run_index in 0..(config.warmups + config.runs) {
+        let is_warmup = run_index < config.warmups;
+        let measured_run_index = run_index.saturating_sub(config.warmups);
+        let result = run_decode(&config, run_index)?;
+
+        if !is_warmup {
+            let record = result.to_json(&config, measured_run_index);
+            serde_json::to_writer(&mut writer, &record)?;
+            writer.write_all(b"\n")?;
+            writer.flush()?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct RunResult {
+    elapsed_ms: u128,
+    object_count: usize,
+    callback_count: usize,
+    pack_hash: String,
+    cache_hits: usize,
+    cache_misses: usize,
+    fallback_loads: usize,
+    base_objects: usize,
+    delta_objects: usize,
+    waitlist_inserts: usize,
+    waitlist_takes: usize,
+    delta_rebuilds: usize,
+    peak_internal_memory_bytes: usize,
+}
+
+impl RunResult {
+    fn to_json(&self, config: &Config, run_index: usize) -> serde_json::Value {
+        let cache_lookups = self.cache_hits + self.cache_misses;
+        let cache_hit_ratio = if cache_lookups == 0 {
+            0.0
+        } else {
+            self.cache_hits as f64 / cache_lookups as f64
+        };
+
+        json!({
+            "run": run_index,
+            "pack": config.pack.display().to_string(),
+            "hash": config.hash.as_str(),
+            "threads": config.threads,
+            "mem_limit_mb": config.mem_limit_mb,
+            "decode_profile_enabled": cfg!(feature = "decode_profile"),
+            "elapsed_ms": self.elapsed_ms,
+            "object_count": self.object_count,
+            "callback_count": self.callback_count,
+            "pack_hash": self.pack_hash,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "cache_hit_ratio": cache_hit_ratio,
+            "fallback_loads": self.fallback_loads,
+            "base_objects": self.base_objects,
+            "delta_objects": self.delta_objects,
+            "waitlist_inserts": self.waitlist_inserts,
+            "waitlist_takes": self.waitlist_takes,
+            "delta_rebuilds": self.delta_rebuilds,
+            "peak_internal_memory_bytes": self.peak_internal_memory_bytes,
+        })
+    }
+}
+
+fn run_decode(config: &Config, run_index: usize) -> Result<RunResult, Box<dyn std::error::Error>> {
+    profile_reset();
+    set_hash_kind(config.hash);
+
+    let file = OpenOptions::new().read(true).open(&config.pack)?;
+    let mut reader = BufReader::new(file);
+    let temp_path = std::env::temp_dir().join(format!(
+        "git-internal-decode-bench-{}-{run_index}",
+        std::process::id()
+    ));
+    let mem_limit = config.mem_limit_mb.map(|mb| mb * 1024 * 1024);
+    let mut pack = Pack::new(Some(config.threads), mem_limit, Some(temp_path), true);
+
+    let callback_count = Arc::new(AtomicUsize::new(0));
+    let callback_count_for_cb = callback_count.clone();
+    let started = Instant::now();
+    pack.decode(
+        &mut reader,
+        move |_| {
+            callback_count_for_cb.fetch_add(1, Ordering::Relaxed);
+        },
+        None::<fn(ObjectHash)>,
+    )?;
+    let elapsed_ms = started.elapsed().as_millis();
+    let snapshot = profile_snapshot();
+
+    Ok(RunResult {
+        elapsed_ms,
+        object_count: pack.number,
+        callback_count: callback_count.load(Ordering::Relaxed),
+        pack_hash: pack.signature.to_string(),
+        cache_hits: snapshot.cache_hits,
+        cache_misses: snapshot.cache_misses,
+        fallback_loads: snapshot.fallback_loads,
+        base_objects: snapshot.base_objects,
+        delta_objects: snapshot.delta_objects,
+        waitlist_inserts: snapshot.waitlist_inserts,
+        waitlist_takes: snapshot.waitlist_takes,
+        delta_rebuilds: snapshot.delta_rebuilds,
+        peak_internal_memory_bytes: snapshot.peak_internal_memory_bytes,
+    })
+}
+
+impl Config {
+    fn parse() -> Result<Self, String> {
+        let mut pack = None;
+        let mut hash = None;
+        let mut threads = None;
+        let mut mem_limit_mb = None;
+        let mut warmups = 0usize;
+        let mut runs = 1usize;
+        let mut out = None;
+
+        let mut args = std::env::args().skip(1);
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--pack" => pack = Some(PathBuf::from(take_value(&mut args, "--pack")?)),
+                "--hash" => {
+                    let value = take_value(&mut args, "--hash")?;
+                    hash = Some(value.parse::<HashKind>()?);
+                }
+                "--threads" => {
+                    threads = Some(parse_usize(
+                        &take_value(&mut args, "--threads")?,
+                        "--threads",
+                    )?)
+                }
+                "--mem-limit-mb" => {
+                    let value = take_value(&mut args, "--mem-limit-mb")?;
+                    mem_limit_mb = if value == "none" {
+                        Some(None)
+                    } else {
+                        Some(Some(parse_usize(&value, "--mem-limit-mb")?))
+                    };
+                }
+                "--warmups" => {
+                    warmups = parse_usize(&take_value(&mut args, "--warmups")?, "--warmups")?
+                }
+                "--runs" => runs = parse_usize(&take_value(&mut args, "--runs")?, "--runs")?,
+                "--out" => {
+                    let value = take_value(&mut args, "--out")?;
+                    if value != "-" {
+                        out = Some(PathBuf::from(value));
+                    }
+                }
+                "--help" | "-h" => return Err(usage()),
+                other => return Err(format!("unknown argument `{other}`\n{}", usage())),
+            }
+        }
+
+        let threads = threads.ok_or_else(|| format!("missing --threads\n{}", usage()))?;
+        if threads == 0 {
+            return Err("--threads must be greater than 0".to_string());
+        }
+        if runs == 0 {
+            return Err("--runs must be greater than 0".to_string());
+        }
+
+        Ok(Config {
+            pack: pack.ok_or_else(|| format!("missing --pack\n{}", usage()))?,
+            hash: hash.ok_or_else(|| format!("missing --hash\n{}", usage()))?,
+            threads,
+            mem_limit_mb: mem_limit_mb.unwrap_or(None),
+            warmups,
+            runs,
+            out,
+        })
+    }
+}
+
+fn take_value(args: &mut impl Iterator<Item = String>, name: &str) -> Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("missing value for `{name}`\n{}", usage()))
+}
+
+fn parse_usize(value: &str, name: &str) -> Result<usize, String> {
+    value
+        .parse::<usize>()
+        .map_err(|_| format!("invalid value for `{name}`: `{value}`"))
+}
+
+fn usage() -> String {
+    "usage: decode_bench --pack <path> --hash sha1|sha256 --threads <n> --mem-limit-mb <n|none> --warmups <n> --runs <n> [--out <path|->]".to_string()
+}

--- a/src/internal/pack/cache.rs
+++ b/src/internal/pack/cache.rs
@@ -70,7 +70,16 @@ impl Caches {
     /// only get object from memory, not from tmp file
     fn try_get(&self, hash: ObjectHash) -> Option<Arc<CacheObject>> {
         let mut map = self.lru_cache.lock().unwrap();
-        map.get(&hash).map(|x| x.data.clone())
+        let obj = map.get(&hash).map(|x| x.data.clone());
+        #[cfg(feature = "decode_profile")]
+        {
+            if obj.is_some() {
+                crate::internal::pack::profile::cache_hit();
+            } else {
+                crate::internal::pack::profile::cache_miss();
+            }
+        }
+        obj
     }
 
     /// !IMPORTANT: because of the process of pack, the file must be written / be writing before, so it won't be dead lock
@@ -81,7 +90,11 @@ impl Caches {
         let obj = {
             loop {
                 match Self::read_from_temp(&path) {
-                    Ok(x) => break x,
+                    Ok(x) => {
+                        #[cfg(feature = "decode_profile")]
+                        crate::internal::pack::profile::fallback_load();
+                        break x;
+                    }
                     Err(e) if e.kind() == io::ErrorKind::NotFound => {
                         sleep(std::time::Duration::from_millis(10));
                         continue;

--- a/src/internal/pack/decode.rs
+++ b/src/internal/pack/decode.rs
@@ -70,7 +70,6 @@ impl<R: BufRead> BufRead for CrcCountingReader<'_, R> {
 
 /// For the convenience of passing parameters
 struct SharedParams {
-    pub pool: Arc<ThreadPool>,
     pub waitlist: Arc<Waitlist>,
     pub caches: Arc<Caches>,
     pub cache_objs_mem_size: Arc<AtomicUsize>,
@@ -318,6 +317,8 @@ impl Pack {
                 let (data, raw_size) = Pack::decompress_data(&mut reader, size)?;
                 *offset += raw_size;
                 let crc32 = hasher.finalize();
+                #[cfg(feature = "decode_profile")]
+                crate::internal::pack::profile::base_object();
                 Ok(Some(CacheObject::new_for_undeltified(
                     t,
                     data,
@@ -353,6 +354,8 @@ impl Pack {
                     _ => unreachable!(),
                 };
                 let crc32 = hasher.finalize();
+                #[cfg(feature = "decode_profile")]
+                crate::internal::pack::profile::delta_object();
                 Ok(Some(CacheObject {
                     info: obj_info,
                     offset: init_offset,
@@ -376,6 +379,8 @@ impl Pack {
 
                 let crc32 = hasher.finalize();
 
+                #[cfg(feature = "decode_profile")]
+                crate::internal::pack::profile::delta_object();
                 Ok(Some(CacheObject {
                     info: CacheObjectInfo::HashDelta(ref_sha, final_size),
                     offset: init_offset,
@@ -426,6 +431,12 @@ impl Pack {
         let callback = Arc::new(callback);
 
         let caches = self.caches.clone();
+        let params = Arc::new(SharedParams {
+            waitlist: self.waitlist.clone(),
+            caches: self.caches.clone(),
+            cache_objs_mem_size: self.cache_objs_mem.clone(),
+            callback: callback.clone(),
+        });
         let mut reader = Wrapper::new(io::BufReader::new(pack));
 
         let result = Pack::check_header(&mut reader);
@@ -465,18 +476,12 @@ impl Pack {
                 Ok(Some(mut obj)) => {
                     obj.set_mem_recorder(self.cache_objs_mem.clone());
                     obj.record_mem_size();
-
-                    // Wrapper of Arc Params, for convenience to pass
-                    let params = Arc::new(SharedParams {
-                        pool: self.pool.clone(),
-                        waitlist: self.waitlist.clone(),
-                        caches: self.caches.clone(),
-                        cache_objs_mem_size: self.cache_objs_mem.clone(),
-                        callback: callback.clone(),
-                    });
+                    #[cfg(feature = "decode_profile")]
+                    self.profile_sample_memory();
 
                     let caches = caches.clone();
                     let waitlist = self.waitlist.clone();
+                    let params = params.clone();
                     let kind = get_hash_kind();
                     self.pool.execute(move || {
                         set_hash_kind(kind);
@@ -643,38 +648,50 @@ impl Pack {
         self.cache_objs_mem.load(Ordering::Acquire)
     }
 
-    /// Rebuild the Delta Object in a new thread & process the objects waiting for it recursively.
-    /// <br> This function must be *static*, because [&self] can't be moved into a new thread.
+    #[cfg(feature = "decode_profile")]
+    fn profile_sample_memory(&self) {
+        crate::internal::pack::profile::sample_peak_internal_memory(self.memory_used());
+    }
+
+    #[cfg(feature = "decode_profile")]
+    fn profile_sample_shared_memory(shared_params: &SharedParams) {
+        let memory = shared_params.cache_objs_mem_size.load(Ordering::Acquire)
+            + shared_params.caches.memory_used_index();
+        crate::internal::pack::profile::sample_peak_internal_memory(memory);
+    }
+
+    /// Rebuild the Delta Object and process the objects waiting for it recursively.
     fn process_delta(
         shared_params: Arc<SharedParams>,
         delta_obj: CacheObject,
         base_obj: Arc<CacheObject>,
     ) {
-        shared_params.pool.clone().execute(move || {
-            let mut new_obj = match delta_obj.info {
-                CacheObjectInfo::OffsetDelta(_, _) | CacheObjectInfo::HashDelta(_, _) => {
-                    Pack::rebuild_delta(delta_obj, base_obj)
-                }
-                CacheObjectInfo::OffsetZstdelta(_, _) => {
-                    Pack::rebuild_zstdelta(delta_obj, base_obj)
-                }
-                _ => unreachable!(),
-            };
+        let mut new_obj = match delta_obj.info {
+            CacheObjectInfo::OffsetDelta(_, _) | CacheObjectInfo::HashDelta(_, _) => {
+                Pack::rebuild_delta(delta_obj, base_obj)
+            }
+            CacheObjectInfo::OffsetZstdelta(_, _) => Pack::rebuild_zstdelta(delta_obj, base_obj),
+            _ => unreachable!(),
+        };
 
-            new_obj.set_mem_recorder(shared_params.cache_objs_mem_size.clone());
-            new_obj.record_mem_size();
-            Self::cache_obj_and_process_waitlist(shared_params, new_obj); //Indirect Recursion
-        });
+        new_obj.set_mem_recorder(shared_params.cache_objs_mem_size.clone());
+        new_obj.record_mem_size();
+        #[cfg(feature = "decode_profile")]
+        Self::profile_sample_shared_memory(&shared_params);
+        Self::cache_obj_and_process_waitlist(shared_params, new_obj); // Indirect recursion.
     }
 
     /// Cache the new object & process the objects waiting for it (in multi-threading).
     fn cache_obj_and_process_waitlist(shared_params: Arc<SharedParams>, new_obj: CacheObject) {
-        (shared_params.callback)(new_obj.to_entry_metadata());
+        let entry = new_obj.to_entry_metadata();
         let new_obj = shared_params.caches.insert(
             new_obj.offset,
             new_obj.base_object_hash().unwrap(),
             new_obj,
         );
+        #[cfg(feature = "decode_profile")]
+        Self::profile_sample_shared_memory(&shared_params);
+        (shared_params.callback)(entry);
         Self::process_waitlist(shared_params, new_obj);
     }
 
@@ -691,6 +708,8 @@ impl Pack {
     /// Reconstruct the Delta Object based on the "base object"
     /// and return the new object.
     pub fn rebuild_delta(delta_obj: CacheObject, base_obj: Arc<CacheObject>) -> CacheObject {
+        #[cfg(feature = "decode_profile")]
+        crate::internal::pack::profile::delta_rebuild();
         const COPY_INSTRUCTION_FLAG: u8 = 1 << 7;
         const COPY_OFFSET_BYTES: u8 = 4;
         const COPY_SIZE_BYTES: u8 = 3;
@@ -777,6 +796,8 @@ impl Pack {
         // Memory recording will happen after this function returns. See `process_delta`
     }
     pub fn rebuild_zstdelta(delta_obj: CacheObject, base_obj: Arc<CacheObject>) -> CacheObject {
+        #[cfg(feature = "decode_profile")]
+        crate::internal::pack::profile::delta_rebuild();
         let result = zstdelta::apply(&base_obj.data_decompressed, &delta_obj.data_decompressed)
             .expect("Failed to apply zstdelta");
         let hash = utils::calculate_object_hash(base_obj.object_type(), &result);

--- a/src/internal/pack/mod.rs
+++ b/src/internal/pack/mod.rs
@@ -9,6 +9,8 @@ pub mod encode;
 pub mod entry;
 mod index_entry;
 pub mod pack_index;
+#[cfg(feature = "decode_profile")]
+pub mod profile;
 pub mod utils;
 pub mod waitlist;
 pub mod wrapper;

--- a/src/internal/pack/pack_index.rs
+++ b/src/internal/pack/pack_index.rs
@@ -83,7 +83,7 @@ impl IdxBuilder {
 
     /// Write the fanout table for the index.
     async fn write_fanout(&mut self, entries: &mut [IndexEntry]) -> Result<(), GitError> {
-        entries.sort_by(|a, b| a.hash.cmp(&b.hash));
+        entries.sort_by_key(|entry| entry.hash);
         let mut fanout = [0u32; 256];
         for entry in entries.iter() {
             fanout[entry.hash.to_data()[0] as usize] += 1;

--- a/src/internal/pack/profile.rs
+++ b/src/internal/pack/profile.rs
@@ -1,0 +1,102 @@
+//! Optional decode profiling counters.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Snapshot of decode profiling counters.
+#[derive(Clone, Copy, Debug, Default, serde::Serialize)]
+pub struct DecodeProfileSnapshot {
+    pub cache_hits: usize,
+    pub cache_misses: usize,
+    pub fallback_loads: usize,
+    pub base_objects: usize,
+    pub delta_objects: usize,
+    pub waitlist_inserts: usize,
+    pub waitlist_takes: usize,
+    pub delta_rebuilds: usize,
+    pub peak_internal_memory_bytes: usize,
+}
+
+static CACHE_HITS: AtomicUsize = AtomicUsize::new(0);
+static CACHE_MISSES: AtomicUsize = AtomicUsize::new(0);
+static FALLBACK_LOADS: AtomicUsize = AtomicUsize::new(0);
+static BASE_OBJECTS: AtomicUsize = AtomicUsize::new(0);
+static DELTA_OBJECTS: AtomicUsize = AtomicUsize::new(0);
+static WAITLIST_INSERTS: AtomicUsize = AtomicUsize::new(0);
+static WAITLIST_TAKES: AtomicUsize = AtomicUsize::new(0);
+static DELTA_REBUILDS: AtomicUsize = AtomicUsize::new(0);
+static PEAK_INTERNAL_MEMORY_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Reset all profiling counters before a benchmark run.
+pub fn reset() {
+    CACHE_HITS.store(0, Ordering::Relaxed);
+    CACHE_MISSES.store(0, Ordering::Relaxed);
+    FALLBACK_LOADS.store(0, Ordering::Relaxed);
+    BASE_OBJECTS.store(0, Ordering::Relaxed);
+    DELTA_OBJECTS.store(0, Ordering::Relaxed);
+    WAITLIST_INSERTS.store(0, Ordering::Relaxed);
+    WAITLIST_TAKES.store(0, Ordering::Relaxed);
+    DELTA_REBUILDS.store(0, Ordering::Relaxed);
+    PEAK_INTERNAL_MEMORY_BYTES.store(0, Ordering::Relaxed);
+}
+
+/// Read the current profiling counters.
+pub fn snapshot() -> DecodeProfileSnapshot {
+    DecodeProfileSnapshot {
+        cache_hits: CACHE_HITS.load(Ordering::Relaxed),
+        cache_misses: CACHE_MISSES.load(Ordering::Relaxed),
+        fallback_loads: FALLBACK_LOADS.load(Ordering::Relaxed),
+        base_objects: BASE_OBJECTS.load(Ordering::Relaxed),
+        delta_objects: DELTA_OBJECTS.load(Ordering::Relaxed),
+        waitlist_inserts: WAITLIST_INSERTS.load(Ordering::Relaxed),
+        waitlist_takes: WAITLIST_TAKES.load(Ordering::Relaxed),
+        delta_rebuilds: DELTA_REBUILDS.load(Ordering::Relaxed),
+        peak_internal_memory_bytes: PEAK_INTERNAL_MEMORY_BYTES.load(Ordering::Relaxed),
+    }
+}
+
+pub(crate) fn cache_hit() {
+    CACHE_HITS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn cache_miss() {
+    CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn fallback_load() {
+    FALLBACK_LOADS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn base_object() {
+    BASE_OBJECTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn delta_object() {
+    DELTA_OBJECTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn waitlist_insert() {
+    WAITLIST_INSERTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn waitlist_take(count: usize) {
+    WAITLIST_TAKES.fetch_add(count, Ordering::Relaxed);
+}
+
+pub(crate) fn delta_rebuild() {
+    DELTA_REBUILDS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn sample_peak_internal_memory(bytes: usize) {
+    let mut current = PEAK_INTERNAL_MEMORY_BYTES.load(Ordering::Relaxed);
+    while bytes > current {
+        match PEAK_INTERNAL_MEMORY_BYTES.compare_exchange_weak(
+            current,
+            bytes,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(observed) => current = observed,
+        }
+    }
+}

--- a/src/internal/pack/waitlist.rs
+++ b/src/internal/pack/waitlist.rs
@@ -22,11 +22,15 @@ impl Waitlist {
 
     /// Insert an object into the waitlist by its pack offset or object hash.
     pub fn insert_offset(&self, offset: usize, obj: CacheObject) {
+        #[cfg(feature = "decode_profile")]
+        crate::internal::pack::profile::waitlist_insert();
         self.map_offset.entry(offset).or_default().push(obj);
     }
 
     /// Insert an object into the waitlist by its object hash.
     pub fn insert_ref(&self, hash: ObjectHash, obj: CacheObject) {
+        #[cfg(feature = "decode_profile")]
+        crate::internal::pack::profile::waitlist_insert();
         self.map_ref.entry(hash).or_default().push(obj);
     }
 
@@ -40,6 +44,8 @@ impl Waitlist {
         if let Some((_, vec)) = self.map_ref.remove(&hash) {
             res.extend(vec);
         }
+        #[cfg(feature = "decode_profile")]
+        crate::internal::pack::profile::waitlist_take(res.len());
         res
     }
 }

--- a/src/protocol/pack.rs
+++ b/src/protocol/pack.rs
@@ -235,16 +235,16 @@ where
                     .await?;
                 }
                 crate::internal::object::tree::TreeItemMode::Blob
-                | crate::internal::object::tree::TreeItemMode::BlobExecutable => {
-                    if !visited_blobs.contains(&entry_hash) {
-                        visited_blobs.insert(entry_hash.clone());
-                        let blob = self.repo_access.get_blob(&entry_hash).await.map_err(|e| {
-                            ProtocolError::repository_error(format!(
-                                "Failed to get blob {entry_hash}: {e}"
-                            ))
-                        })?;
-                        blobs.push(blob);
-                    }
+                | crate::internal::object::tree::TreeItemMode::BlobExecutable
+                    if !visited_blobs.contains(&entry_hash) =>
+                {
+                    visited_blobs.insert(entry_hash.clone());
+                    let blob = self.repo_access.get_blob(&entry_hash).await.map_err(|e| {
+                        ProtocolError::repository_error(format!(
+                            "Failed to get blob {entry_hash}: {e}"
+                        ))
+                    })?;
+                    blobs.push(blob);
                 }
                 _ => {}
             }


### PR DESCRIPTION
Add decode_bench example and feature-gated decode profiling counters. Hoist shared decode state, process delta rebuilds inline in decode workers, and cache resolved objects before callback dispatch. Also clean up clippy warnings in pack index and protocol pack traversal.