### PR TITLE
fix: use git index ctime on v9fs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "git-internal"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "git-internal"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-internal"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 authors = ["Eli Ma <genedna@gmail.com>"]
 description = "High-performance Rust library for Git internal objects, Pack files, and AI-assisted development objects (Intent, Plan, Task, Run, Evidence, Decision) with delta compression, streaming I/O, and smart protocol support."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-internal"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["Eli Ma <genedna@gmail.com>"]
 description = "High-performance Rust library for Git internal objects, Pack files, and AI-assisted development objects (Intent, Plan, Task, Run, Evidence, Decision) with delta compression, streaming I/O, and smart protocol support."

--- a/src/internal/index.rs
+++ b/src/internal/index.rs
@@ -3,6 +3,8 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+#[cfg(unix)]
+use std::time::Duration;
 use std::{
     collections::BTreeMap,
     fmt::{Display, Formatter},
@@ -61,6 +63,44 @@ impl Display for Time {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}", self.seconds, self.nanos)
     }
+}
+
+#[cfg(unix)]
+fn index_ctime(meta: &fs::Metadata) -> SystemTime {
+    unix_metadata_time(meta.ctime(), meta.ctime_nsec())
+}
+
+#[cfg(not(unix))]
+fn index_ctime(meta: &fs::Metadata) -> SystemTime {
+    meta.created()
+        .or_else(|_| meta.modified())
+        .unwrap_or(UNIX_EPOCH)
+}
+
+#[cfg(unix)]
+fn index_mtime(meta: &fs::Metadata) -> SystemTime {
+    unix_metadata_time(meta.mtime(), meta.mtime_nsec())
+}
+
+#[cfg(not(unix))]
+fn index_mtime(meta: &fs::Metadata) -> SystemTime {
+    meta.modified()
+        .or_else(|_| meta.created())
+        .unwrap_or(UNIX_EPOCH)
+}
+
+#[cfg(unix)]
+fn unix_metadata_time(seconds: i64, nanos: i64) -> SystemTime {
+    if seconds < 0 {
+        return UNIX_EPOCH;
+    }
+
+    let nanos = u32::try_from(nanos)
+        .ok()
+        .filter(|nanos| *nanos < 1_000_000_000)
+        .unwrap_or(0);
+
+    UNIX_EPOCH + Duration::new(seconds as u64, nanos)
 }
 
 /// 16 bits
@@ -151,8 +191,8 @@ impl IndexEntry {
     /** Metadata must be got by [fs::symlink_metadata] to avoid following symlink */
     pub fn new(meta: &fs::Metadata, hash: ObjectHash, name: String) -> Self {
         let mut entry = IndexEntry {
-            ctime: Time::from_system_time(meta.created().unwrap()),
-            mtime: Time::from_system_time(meta.modified().unwrap()),
+            ctime: Time::from_system_time(index_ctime(meta)),
+            mtime: Time::from_system_time(index_mtime(meta)),
             dev: 0,
             ino: 0,
             uid: 0,
@@ -384,17 +424,8 @@ impl Index {
         if let Some(entry) = self.entries.get_mut(&(name.to_string(), 0)) {
             let abs_path = workdir.join(path);
             let meta = fs::symlink_metadata(&abs_path)?;
-            // Try creation time; on error, warn and use modification time (or now)
-            let new_ctime = Time::from_system_time(Self::time_or_now(
-                "creation time",
-                &abs_path,
-                meta.created(),
-            ));
-            let new_mtime = Time::from_system_time(Self::time_or_now(
-                "modification time",
-                &abs_path,
-                meta.modified(),
-            ));
+            let new_ctime = Time::from_system_time(index_ctime(&meta));
+            let new_mtime = Time::from_system_time(index_mtime(&meta));
             let new_size = meta.len() as u32;
 
             // re-calculate SHA1/SHA256
@@ -417,21 +448,6 @@ impl Index {
             }
         }
         Ok(false)
-    }
-
-    /// Try to get a timestamp, logging on error, and finally falling back to now.
-    fn time_or_now(what: &str, path: &Path, res: io::Result<SystemTime>) -> SystemTime {
-        match res {
-            Ok(ts) => ts,
-            Err(e) => {
-                eprintln!(
-                    "warning: failed to get {what} for {path:?}: {e}; using SystemTime::now()",
-                    what = what,
-                    path = path.display()
-                );
-                SystemTime::now()
-            }
-        }
     }
 }
 
@@ -491,10 +507,8 @@ impl Index {
             let path_abs = workdir.join(file);
             let meta = path_abs.symlink_metadata().unwrap();
             // TODO more fields
-            let same = entry.ctime
-                == Time::from_system_time(meta.created().unwrap_or(SystemTime::now()))
-                && entry.mtime
-                    == Time::from_system_time(meta.modified().unwrap_or(SystemTime::now()))
+            let same = entry.ctime == Time::from_system_time(index_ctime(&meta))
+                && entry.mtime == Time::from_system_time(index_mtime(&meta))
                 && entry.size == meta.len() as u32;
 
             !same


### PR DESCRIPTION
﻿## Summary
- Fix Git index entry timestamp creation on filesystems where birth/creation time is unavailable, such as WSL 9p/drvfs paths.
- Keep index metadata stable by using ctime on Unix and falling back safely instead of unwrapping `Metadata::created()`.

## Validation
- Reproduced the old panic with pre-fix Libra `1b4665f0` on `/mnt/d/code/rustpan` where `stat tracked.txt` reports `Birth: -`.
- Old `libra add tracked.txt` failed with `creation time is not available for the filesystem` at `git-internal-0.8.1/src/internal/index.rs:154`.
- Synced `Ivanbeethoven/git-internal@20d2810` with `Ivanbeethoven/libra@d48c9721` using Libra's local `../git-internal` patch.
- Ran `LIBRA_SKIP_WEB_BUILD=1 cargo check --locked --bin libra` and `LIBRA_SKIP_WEB_BUILD=1 cargo build --locked --bin libra`.
- Verified fixed `libra add tracked.txt` succeeds on `/mnt/d/code/rustpan/libra-v9fs-fixed-worktree-test`; `libra status --short` reports `A  tracked.txt`.
